### PR TITLE
feat: added Docker support and integrate with CI for Playwright .NET tests

### DIFF
--- a/.github/workflows/ci-playwright.yml
+++ b/.github/workflows/ci-playwright.yml
@@ -19,27 +19,20 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.x
-
-    # Build each project
-    - name: Build project solution
-      run: dotnet build ${{ matrix.project }}/${{ matrix.project }}.csproj --configuration Release
-    
-    # Install Playwright browsers in each project
-    - name: Install Playwright browsers
-      run: pwsh ${{ matrix.project }}/bin/Release/net8.0/playwright.ps1 install --with-deps
+    - name: Build docker image
+      run: docker build -t saucedemo-tests .
 
     # Run UI tests when pushing to feature branch
     - name: Run ${{ matrix.project }} - UI tests
       if: github.ref != 'refs/heads/main'
-      run: dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=UI --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_UI_Results.trx"
+      # run: dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=UI --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_UI_Results.trx"
+      run: docker run --rm -v ${{ github.workspace }}/Reports:/src/Reports saucedemo-tests dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=UI --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_UI_Results.trx"
 
     # Run E2E tests when merging to main branch
     - name: Run ${{ matrix.project }} - E2E tests
       if: github.ref == 'refs/heads/main'
-      run: dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=E2E --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_E2E_Results.trx"
+      # run: dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=E2E --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_E2E_Results.trx"
+      run: docker run --rm -v ${{ github.workspace }}/Reports:/src/Reports saucedemo-tests dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=E2E --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_E2E_Results.trx"
 
     # Upload test results for each project
     - name: Upload ${{ matrix.project }} test results

--- a/.github/workflows/ci-playwright.yml
+++ b/.github/workflows/ci-playwright.yml
@@ -22,19 +22,35 @@ jobs:
     - name: Build docker image
       run: |
         cd ${{ matrix.project }}
-        docker build -t saucedemo-tests .
+        docker build -t ${{ matrix.project }}-tests .
 
     # Run UI tests when pushing to feature branch
     - name: Run ${{ matrix.project }} - UI tests
       if: github.ref != 'refs/heads/main'
       # run: dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=UI --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_UI_Results.trx"
-      run: docker run --rm -v ${{ github.workspace }}/Reports:/src/Reports saucedemo-tests dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=UI --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_UI_Results.trx"
+      run: |
+        docker run --rm \
+          -v ${{ github.workspace }}/Reports:/src/Reports \
+          ${{ matrix.project }}-tests \
+          dotnet test /src/${{ matrix.project }}.csproj \
+            --filter Category=UI \
+            --no-build \
+            --configuration Release \
+            --logger "trx;LogFileName=${{ matrix.project }}_UI_Results.trx"
 
     # Run E2E tests when merging to main branch
     - name: Run ${{ matrix.project }} - E2E tests
       if: github.ref == 'refs/heads/main'
       # run: dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=E2E --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_E2E_Results.trx"
-      run: docker run --rm -v ${{ github.workspace }}/Reports:/src/Reports saucedemo-tests dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=E2E --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_E2E_Results.trx"
+      run: |
+        docker run --rm \
+          -v ${{ github.workspace }}/Reports:/src/Reports \
+          ${{ matrix.project }}-tests \
+          dotnet test /src/${{ matrix.project }}.csproj \
+            --filter Category=E2E \
+            --no-build \
+            --configuration Release \
+            --logger "trx;LogFileName=${{ matrix.project }}_E2E_Results.trx"
 
     # Upload test results for each project
     - name: Upload ${{ matrix.project }} test results

--- a/.github/workflows/ci-playwright.yml
+++ b/.github/workflows/ci-playwright.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build docker image
       run: |
         cd ${{ matrix.project }}
-        docker build -t ${{ matrix.project }}-tests .
+        docker build -t playwright-tests-image .
 
     # Run UI tests when pushing to feature branch
     - name: Run ${{ matrix.project }} - UI tests

--- a/.github/workflows/ci-playwright.yml
+++ b/.github/workflows/ci-playwright.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         docker run --rm \
           -v ${{ github.workspace }}/Reports:/src/Reports \
-          ${{ matrix.project }}-tests \
+          playwright-tests-image \
           dotnet test /src/${{ matrix.project }}.csproj \
             --filter Category=UI \
             --no-build \
@@ -45,7 +45,7 @@ jobs:
       run: |
         docker run --rm \
           -v ${{ github.workspace }}/Reports:/src/Reports \
-          ${{ matrix.project }}-tests \
+          playwright-tests-image \
           dotnet test /src/${{ matrix.project }}.csproj \
             --filter Category=E2E \
             --no-build \

--- a/.github/workflows/ci-playwright.yml
+++ b/.github/workflows/ci-playwright.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Build docker image
-      run: docker build -t saucedemo-tests .
+      run: docker build -t saucedemo-tests -f ${{ matrix.project }}/Dockerfile .
 
     # Run UI tests when pushing to feature branch
     - name: Run ${{ matrix.project }} - UI tests

--- a/.github/workflows/ci-playwright.yml
+++ b/.github/workflows/ci-playwright.yml
@@ -20,7 +20,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Build docker image
-      run: docker build -t saucedemo-tests -f ${{ matrix.project }}/Dockerfile .
+      run: |
+        cd ${{ matrix.project }}
+        docker build -t saucedemo-tests .
 
     # Run UI tests when pushing to feature branch
     - name: Run ${{ matrix.project }} - UI tests

--- a/.github/workflows/ci-playwright.yml
+++ b/.github/workflows/ci-playwright.yml
@@ -27,7 +27,6 @@ jobs:
     # Run UI tests when pushing to feature branch
     - name: Run ${{ matrix.project }} - UI tests
       if: github.ref != 'refs/heads/main'
-      # run: dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=UI --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_UI_Results.trx"
       run: |
         docker run --rm \
           -v ${{ github.workspace }}/Reports:/src/Reports \
@@ -41,7 +40,6 @@ jobs:
     # Run E2E tests when merging to main branch
     - name: Run ${{ matrix.project }} - E2E tests
       if: github.ref == 'refs/heads/main'
-      # run: dotnet test ${{ matrix.project }}/${{ matrix.project }}.csproj --filter Category=E2E --no-build --configuration Release --logger "trx;LogFileName=${{ matrix.project }}_E2E_Results.trx"
       run: |
         docker run --rm \
           -v ${{ github.workspace }}/Reports:/src/Reports \
@@ -58,4 +56,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.project }} - Report
-        path: ${{ matrix.project }}/Reports/
+        path: Reports/

--- a/Playwright.SauceDemo/.dockerignore
+++ b/Playwright.SauceDemo/.dockerignore
@@ -1,0 +1,36 @@
+# .NET build
+bin/
+obj/
+*.user
+*.rsuser
+*.suo
+*.cache
+*.log
+.vs/
+
+# IDE settings
+.idea/
+.vscode/
+
+# Test results
+TestResult*/
+*.trx
+*.coverage
+*.coveragexml
+TestResults/
+Reports/
+test-results/
+playwright-report/
+
+# Playwright downloaded browsers
+playwright/.local-browsers/
+bin/**/playwright/.local-browsers/
+bin/**/playwright/.cache/
+
+# Git files (optional)
+.git/
+.gitignore
+
+# Docker files (optional)
+Dockerfile
+docker-compose*

--- a/Playwright.SauceDemo/Dockerfile
+++ b/Playwright.SauceDemo/Dockerfile
@@ -1,47 +1,14 @@
-# Stage 1 - Build
-# Base image of .NET SDK from Microsoft
+# Build stage
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-
-# Install systems dependencies for Playwright (Prerequisite step; Only for .NET)
-RUN apt-get update && apt-get install -y \
-    libnss3 libatk1.0-0 libcups2 libxss1 libasound2 \
-    libx11-xcb1 libxcomposite1 libxdamage1 libxrandr2 \
-    libgbm1 libgtk-3-0 fonts-liberation wget curl \
-    --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
-
-# Set working directory in container
 WORKDIR /app
-
-# Create folders for test outputs
-RUN mkdir -p /app/TestResults /app/Reports
-
-# Copy csproj and run dotnet restore
-COPY Playwright.SauceDemo.csproj ./
-RUN dotnet restore Playwright.SauceDemo.csproj
-
-# Copy source files and build
+COPY *.csproj ./
+RUN dotnet restore
 COPY . ./
-RUN dotnet build Playwright.SauceDemo.csproj --configuration Release
+RUN dotnet build -c Release --no-restore
 
-# Install Playwright browsers and CLI
-RUN pwsh ./bin/Release/net8.0/playwright.ps1 install --with-deps
-
-# Stage 2 - Runtime
-# Base image of .NET SDK from Microsoft
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS runtime
-
-# Set working directory in container
-WORKDIR /app
-
-# Copy only compiled binaries and Playwright installation from build stage
+# Runtime stage using Playwright's official docker image
+FROM mcr.microsoft.com/playwright/dotnet:v1.55.0-jammy AS final
+WORKDIR /src
 COPY --from=build /app ./
-
-# Reinstall Playwright browsers in runtime stage
-RUN pwsh ./bin/Release/net8.0/playwright.ps1 install --with-deps
-
-# Set PATH for Playwright CLI if needed
-ENV PATH="$PATH:/root/.dotnet/tools"
-
-# Run tests
+RUN mkdir -p /src/Reports
 CMD ["dotnet", "test", "Playwright.SauceDemo.csproj", "--configuration", "Release"]

--- a/Playwright.SauceDemo/Dockerfile
+++ b/Playwright.SauceDemo/Dockerfile
@@ -1,41 +1,47 @@
+# Stage 1 - Build
 # Base image of .NET SDK from Microsoft
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 # Install systems dependencies for Playwright (Prerequisite step; Only for .NET)
 RUN apt-get update && apt-get install -y \
-    libnss3 \
-    libatk1.0-0 \
-    libcups2 \
-    libxss1 \
-    libasound2 \
-    libx11-xcb1 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxrandr2 \
-    libgbm1 \
-    libgtk-3-0 \
-    fonts-liberation \
-    wget \
-    curl \
+    libnss3 libatk1.0-0 libcups2 libxss1 libasound2 \
+    libx11-xcb1 libxcomposite1 libxdamage1 libxrandr2 \
+    libgbm1 libgtk-3-0 fonts-liberation wget curl \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
 # Set working directory in container
 WORKDIR /app
 
-# Optional: pre-create TestResults folder to avoid errors
-# Your test framework may create it automatically, but this ensures safety
-RUN mkdir -p /app/TestResults
+# Create folders for test outputs
+RUN mkdir -p /app/TestResults /app/Reports
 
-# Copy project files into the container
-COPY ..
+# Copy csproj and run dotnet restore
+COPY Playwright.SauceDemo.csproj ./
+RUN dotnet restore Playwright.SauceDemo.csproj
 
-# Restore NuGet packages and build the project
-RUN dotnet restorew
-RUN dotnet build --configuration Release
+# Copy source files and build
+COPY . ./
+RUN dotnet build Playwright.SauceDemo.csproj --configuration Release
 
 # Install Playwright browsers and CLI
-RUN dotnet tool install --global Microsoft.Playwright.CLI && playwright install --with-deps
+RUN pwsh ./bin/Release/net8.0/playwright.ps1 install --with-deps
+
+# Stage 2 - Runtime
+# Base image of .NET SDK from Microsoft
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS runtime
+
+# Set working directory in container
+WORKDIR /app
+
+# Copy only compiled binaries and Playwright installation from build stage
+COPY --from=build /app ./
+
+# Reinstall Playwright browsers in runtime stage
+RUN pwsh ./bin/Release/net8.0/playwright.ps1 install --with-deps
+
+# Set PATH for Playwright CLI if needed
+ENV PATH="$PATH:/root/.dotnet/tools"
 
 # Run tests
-CMD ["dotnet", "tests", "--configuration", "Release"]
+CMD ["dotnet", "test", "Playwright.SauceDemo.csproj", "--configuration", "Release"]

--- a/Playwright.SauceDemo/Dockerfile
+++ b/Playwright.SauceDemo/Dockerfile
@@ -2,9 +2,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 COPY *.csproj ./
-RUN dotnet restore
+RUN dotnet restore Playwright.SauceDemo.csproj
 COPY . ./
-RUN dotnet build -c Release --no-restore
+RUN dotnet build Playwright.SauceDemo.csproj -c Release --no-restore
 
 # Runtime stage using Playwright's official docker image
 FROM mcr.microsoft.com/playwright/dotnet:v1.55.0-jammy AS final

--- a/Playwright.SauceDemo/Dockerfile
+++ b/Playwright.SauceDemo/Dockerfile
@@ -1,8 +1,8 @@
 # Build stage
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
-COPY *.csproj ./
-RUN dotnet restore Playwright.SauceDemo.csproj
+COPY Playwright.SauceDemo.csproj ./
+RUN dotnet restore
 COPY . ./
 RUN dotnet build Playwright.SauceDemo.csproj -c Release --no-restore
 

--- a/Playwright.SauceDemo/Dockerfile
+++ b/Playwright.SauceDemo/Dockerfile
@@ -1,0 +1,41 @@
+# Base image of .NET SDK from Microsoft
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+# Install systems dependencies for Playwright (Prerequisite step; Only for .NET)
+RUN apt-get update && apt-get install -y \
+    libnss3 \
+    libatk1.0-0 \
+    libcups2 \
+    libxss1 \
+    libasound2 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libgtk-3-0 \
+    fonts-liberation \
+    wget \
+    curl \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set working directory in container
+WORKDIR /app
+
+# Optional: pre-create TestResults folder to avoid errors
+# Your test framework may create it automatically, but this ensures safety
+RUN mkdir -p /app/TestResults
+
+# Copy project files into the container
+COPY ..
+
+# Restore NuGet packages and build the project
+RUN dotnet restorew
+RUN dotnet build --configuration Release
+
+# Install Playwright browsers and CLI
+RUN dotnet tool install --global Microsoft.Playwright.CLI && playwright install --with-deps
+
+# Run tests
+CMD ["dotnet", "tests", "--configuration", "Release"]


### PR DESCRIPTION
This pull request includes:

- Added Dockerfile and .dockerignore for Playwright .NET project.
- Modify Dockerfile to use Playwright's official base image.
- Updated CI workflow to:
1. Build Docker image during pipeline.
2. Run UI and E2E tests inside Docker container.
3. Upload test reports from container to GitHub artifacts.